### PR TITLE
[redirect][m] - fix redirect bug with vuepress-plugin-rehydrate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11656,6 +11656,15 @@
         "markdown-it-container": "^2.0.0"
       }
     },
+    "vuepress-plugin-dehydrate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-dehydrate/-/vuepress-plugin-dehydrate-1.1.3.tgz",
+      "integrity": "sha512-alSW3BXgwmm1U9F6UmeFvP58t0xluNkzxQ9OfsWTq+UG8UyUsdqV6ltaii6wWA0cmlfqOswdQXwgcifJ6jAIfw==",
+      "dev": true,
+      "requires": {
+        "@vuepress/shared-utils": "^1.2.0"
+      }
+    },
     "vuepress-plugin-disqus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-disqus/-/vuepress-plugin-disqus-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "cypress": "^3.8.3",
     "start-server-and-test": "^1.10.8",
     "tailwindcss": "^1.1.4",
-    "vuepress": "^1.2.0"
+    "vuepress": "^1.2.0",
+    "vuepress-plugin-dehydrate": "^1.1.3"
   },
   "scripts": {
     "build": "npx vuepress build site",

--- a/site/.vuepress/config.js
+++ b/site/.vuepress/config.js
@@ -125,7 +125,18 @@ module.exports = {
         ]
       }
     ],
-    ["@vuepress/back-to-top"]
+    ["@vuepress/back-to-top"],
+    ["vuepress-plugin-dehydrate", {
+      // disable SSR
+      noSSR: '404.html',
+      // remove scripts
+      noScript: [
+        // support glob patterns
+        'foo/*.html',
+        '**/static.html',
+      ],
+    }
+  ]
   ],
   head: [
     ["script", { src: "https://unpkg.com/honeycomb-grid@3.1.3" }],


### PR DESCRIPTION
There's a bug when you are redirected to frictionlessdata.io and you have to reload the page to see the result else it'll lead to a 404 page.

I found a workaround fix and it can only be tested in production since the bug can only be reproduced in production. This PR checks if my solution works.


Issue: https://github.com/frictionlessdata/project/issues/448